### PR TITLE
DASD-15725 - Decommission employer provide feedback UI as the UI now lives in employer-feedback-web

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -116,7 +116,10 @@
             "type": "int"
         },
         "uiCustomHostname": {
-            "type": "string"
+            "type": "string",
+            "metadata": {
+                "description": "Public URL of the employer feedback site. Since DASD-14308 this hostname is served by das-<env>-empfbui-as (das-employer-feedback-web), not by this service. Retained solely to build EmailSettings:FeedbackSiteBaseUrl for invitation emails - do not bind it to an app service here."
+            }
         },
         "apiCustomHostname": {
             "type": "string",
@@ -201,7 +204,10 @@
             "type": "string"
         },
         "uiCertificateName": {
-            "type": "string"
+            "type": "string",
+            "metadata": {
+                "description": "No longer used - the UI app service was decommissioned (superseded by das-employer-feedback-web, DASD-14308). Declaration retained because the deployment parameters file is generated from pipeline variables; remove only once UICertificateName is removed from the RELEASE variable group."
+            }
         },
         "apiCertificateName": {
             "type": "string"
@@ -250,7 +256,6 @@
         "storageAccountName": "[toLower(concat('das', parameters('resourceEnvironmentName'), parameters('serviceName'), 'str'))]",
         "serviceBusNamespaceName": "[concat(variables('resourceNamePrefix'), '-ns')]",
         "apiAppServiceName": "[concat(variables('resourceNamePrefix'), 'api-as')]",
-        "uiAppServiceName": "[concat(variables('resourceNamePrefix'), 'ui-as')]",
         "functionAppName": "[concat(variables('resourceNamePrefix'), 'wkr-fa')]",
         "functionAppPlanName": "[concat(variables('resourceNamePrefix'), 'wkr-asp')]",
         "databaseName": "[concat(variables('resourceNamePrefix'), '-db')]",
@@ -300,193 +305,6 @@
                     },
                     "minimumTlsVersion": {
                         "value": "[parameters('minimumTlsVersion')]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "2021-04-01",
-            "name": "[concat(variables('uiAppServiceName'), '-app-service-certificate-', parameters('utcValue'))]",
-            "type": "Microsoft.Resources/deployments",
-            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-certificate.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "keyVaultCertificateName": {
-                        "value": "[parameters('uiCertificateName')]"
-                    },
-                    "keyVaultName": {
-                        "value": "[parameters('sharedKeyVaultName')]"
-                    },
-                    "keyVaultResourceGroup": {
-                        "value": "[parameters('sharedManagementResourceGroup')]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "2021-04-01",
-            "name": "[concat(variables('uiAppServiceName'), '-application-insights-', parameters('utcValue'))]",
-            "type": "Microsoft.Resources/deployments",
-            "resourceGroup": "[variables('resourceGroupName')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'), 'application-insights.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "appInsightsName": {
-                        "value": "[variables('uiAppServiceName')]"
-                    },
-                    "attachedService": {
-                        "value": "[variables('uiAppServiceName')]"
-                    }
-                }
-            }
-        },
-        {
-            "condition": "[parameters('deployPrivateLinkedScopedResource')]",
-            "apiVersion": "2021-04-01",
-            "name": "[concat(variables('uiAppServiceName'), '-private-link-scoped-', parameters('utcValue'))]",
-            "type": "Microsoft.Resources/deployments",
-            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'),'private-linked-scoped-resource.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "privateLinkScopeName": {
-                        "value": "[variables('privateLinkScopeName')]"
-                    },
-                    "scopedResourceName": {
-                        "value": "[variables('uiAppServiceName')]"
-                    },
-                    "scopedResourceId": {
-                        "value": "[reference(concat(variables('uiAppServiceName'), '-application-insights-', parameters('utcValue'))).outputs.AppInsightsResourceId.value]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "2021-04-01",
-            "name": "[concat(variables('uiAppServiceName'), '-', parameters('utcValue'))]",
-            "type": "Microsoft.Resources/deployments",
-            "resourceGroup": "[variables('resourceGroupName')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'), 'app-service-v2.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "appServiceName": {
-                        "value": "[variables('uiAppServiceName')]"
-                    },
-                    "appServicePlanName": {
-                        "value": "[parameters('sharedFrontEndAppServicePlanName')]"
-                    },
-                    "appServicePlanResourceGroup": {
-                        "value": "[parameters('sharedEnvResourceGroup')]"
-                    },
-                    "subnetResourceId": {
-                        "value": "[parameters('sharedFrontEndSubnetResourceId')]"
-                    },
-                    "appServiceAppSettings": {
-                        "value": {
-                            "array": [
-                                {
-                                    "name": "Environment",
-                                    "value": "[parameters('environmentName')]"
-                                },
-                                {
-                                    "name": "EnvironmentName",
-                                    "value": "[parameters('environmentName')]"
-                                },
-                                {
-                                    "name": "ResourceEnvironmentName",
-                                    "value": "[parameters('resourceEnvironmentName')]"
-                                },
-                                {
-                                    "name": "ConfigurationStorageConnectionString",
-                                    "value": "[parameters('configurationStorageConnectionString')]"
-                                },
-                                {
-                                    "name": "ConfigNames",
-                                    "value": "[parameters('configNames')]"
-                                },
-                                {
-                                    "name": "Version",
-                                    "value": "1.0"
-                                },
-                                {
-                                    "name": "LoggingRedisConnectionString",
-                                    "value": "[parameters('loggingRedisConnectionString')]"
-                                },
-                                {
-                                    "name": "LoggingRedisKey",
-                                    "value": "[parameters('loggingRedisKey')]"
-                                },
-                                {
-                                    "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
-                                    "value": "[reference(concat(variables('uiAppServiceName'), '-application-insights-', parameters('utcValue'))).outputs.ConnectionString.value]"
-                                },
-                                {
-                                    "name": "ASPNETCORE_ENVIRONMENT",
-                                    "value": "[parameters('aspNetCoreEnvironment')]"
-                                },
-                                {
-                                    "name": "StubAuth",
-                                    "value": "[parameters('stubAuth')]"
-                                },
-                                {
-                                    "name": "Cdn:Url",
-                                    "value": "[parameters('cdnUrl')]"
-                                }
-                            ]
-                        }
-                    },
-                    "customHostName": {
-                        "value": "[parameters('uiCustomHostname')]"
-                    },
-                    "certificateThumbprint": {
-                        "value": "[reference(concat(variables('uiAppServiceName'), '-app-service-certificate-', parameters('utcValue'))).outputs.certificateThumbprint.value]"
-                    },
-                    "ipSecurityRestrictions": {
-                        "value": "[parameters('frontEndAccessRestrictions')]"
-                    },
-                    "vnetRouteAllEnabled": {
-                        "value": "[parameters('vnetRouteAllEnabled')]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "2020-06-01",
-            "name": "[concat('apim-product-subscription-', parameters('utcValue'))]",
-            "resourceGroup": "[parameters('sharedApimResourceGroup')]",
-            "type": "Microsoft.Resources/deployments",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'),'apim/apim-subscription.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "apimName": {
-                        "value": "[parameters('sharedApimName')]"
-                    },
-                    "subscriptionName": {
-                        "value": "[variables('uiAppServiceName')]"
-                    },
-                    "subscriptionScope": {
-                        "value": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('sharedApimResourceGroup'), '/providers/Microsoft.ApiManagement/service/', parameters('sharedApimName'), '/products/EmployerFeedbackOuterApi')]"
                     }
                 }
             }
@@ -1039,10 +857,6 @@
         }
     ],
     "outputs": {
-        "UIAppServiceName": {
-            "type": "string",
-            "value": "[variables('uiAppServiceName')]"
-        },
         "ApiAppServiceName": {
             "type": "string",
             "value": "[variables('apiAppServiceName')]"

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -29,16 +29,6 @@ jobs:
       zipAfterPublish: true
 
   - task: DotNetCoreCLI@2
-    displayName: Publish - dotnet publish UIApp
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: src/Employer/${{ parameters.SolutionBaseName }}/${{ parameters.SolutionBaseName }}.csproj
-      arguments: -o $(build.artifactstagingdirectory)/publish -c ${{ parameters.BuildConfiguration }} --no-build
-      modifyOutputPath: true
-      zipAfterPublish: true
-
-  - task: DotNetCoreCLI@2
     displayName: Publish - dotnet publish ApiApp
     inputs:
       command: publish

--- a/pipeline-templates/job/deploy.yml
+++ b/pipeline-templates/job/deploy.yml
@@ -50,43 +50,11 @@ jobs:
             ResourceName: $(FunctionAppName)
             Tenant: $(Tenant)
             IsMultiRepoCheckout: true
-        - template: azure-pipelines-templates/deploy/step/app-role-assignments.yml@das-platform-building-blocks
-          parameters:
-            ServiceConnection: ${{ parameters.AppRoleAssignmentsServiceConnection }}
-            ResourceName: $(UIAppServiceName)
-            Tenant: $(Tenant)
-            IsMultiRepoCheckout: true
-        - template: azure-pipelines-templates/deploy/step/get-apim-subscription-key.yml@das-platform-building-blocks
-          parameters:
-            ServiceConnection: ${{ parameters.ServiceConnection }}
-            ApimResourceGroup: $(SharedApimResourceGroup)
-            ApimName: $(SharedApimName)
-            SubscriptionId: $(UIAppServiceName)
-            PipelineVariableName: EmployerFeedbackApimSubscriptionKey
-            IsMultiRepoCheckout: true
-        - template: azure-pipelines-templates/deploy/step/generate-config.yml@das-platform-building-blocks
-          parameters:
-            EnvironmentName: $(EnvironmentName)
-            ServiceConnection: ${{ parameters.ServiceConnection }}
-            SourcePath: $(Pipeline.Workspace)/das-employer-config/Configuration/das-provide-feedback-employer
-            StorageAccountName: $(ConfigurationStorageAccountName)
-            StorageAccountResourceGroup: $(SharedEnvResourceGroup)
-            TargetFileName: '*.schema.json'
-            TableName: Configuration
-            ConfigurationSecrets:
-              SharedRedisConnectionString: $(SharedRedisConnectionString)
-              AuthenticationClientSecret: $(AuthenticationClientSecret)
-              EmployerFeedbackApimSubscriptionKey: $(EmployerFeedbackApimSubscriptionKey)
         - template: azure-pipelines-templates/deploy/step/function-deploy.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             FunctionAppName: $(FunctionAppName)
             DeploymentPackagePath: $(Pipeline.Workspace)/${{ parameters.SolutionBaseName }}/ESFA.DAS.ProvideFeedback.Employer.Functions.Emailer.zip
-        - template: azure-pipelines-templates/deploy/step/app-deploy.yml@das-platform-building-blocks
-          parameters:
-            ServiceConnection: ${{ parameters.ServiceConnection }}
-            AppServiceName: $(UIAppServiceName)
-            DeploymentPackagePath: $(Pipeline.Workspace)/${{ parameters.SolutionBaseName }}/${{ parameters.SolutionBaseName }}.zip
         - template: azure-pipelines-templates/deploy/step/app-deploy.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}


### PR DESCRIPTION
The employer feedback UI was superseded by das-employer-feedback-web. DASD-14308 (PR 53276, 08/12/2025) switched
feedback.<env>-eas.apprenticeships.education.gov.uk from das-<env>-pfbeui-as to das-<env>-empfbui-as across all environments, so no App Gateway route or DNS record points at this repo's UI app service any more. das-at-pfbeui-as is already stopped.

This left deployments failing: the ARM template still tried to bind a custom hostname now owned by another app service, which Azure rejects with BadRequest. The last successful deployment was 7a7371c (10/09/2025), before the cutover.

This repo now deploys the API and the emailer function only.

azure/template.json
  - remove the UI app service, its app service certificate, Application Insights, private link scoped resource and the APIM product subscription registered under the UI app service name
  - remove the uiAppServiceName variable and UIAppServiceName output
  - retain uiCustomHostname: it also builds EmailSettings:FeedbackSiteBaseUrl for invitation emails, and now correctly points at the replacement service
  - retain the uiCertificateName declaration, unused, as the deployment parameters file is generated from pipeline variables

pipeline-templates/job/deploy.yml
  - remove the UI app role assignment, APIM subscription key and UI app deploy steps
  - remove generate-config: only the UI read configuration from table storage, so the step no longer has a consumer

pipeline-templates/job/code-build.yml
  - remove the UI publish task, its artifact is no longer deployed

Note that ARM deploys in Incremental mode, so this does not delete the existing Azure resources. Removing das-<env>-pfbeui-as, its staging slot, Application Insights and the APIM subscription, along with the UICertificateName variable group entry and the
SFA.DAS.ProvideFeedbackEmployer.Web files in das-employer-config, is tracked separately.